### PR TITLE
Update README root URL description

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ This repository contains a minimal Django project configured to use PostgreSQL a
    python manage.py runserver
    ```
 
-Visit `http://127.0.0.1:8000/` to see the default Django page.
+Visit `http://127.0.0.1:8000/` to see the LMS app's index page. You
+should see a simple `LMS backend is running` message, confirming that the
+backend is active.
 
 ## Requirements File
 


### PR DESCRIPTION
## Summary
- clarify that the root URL shows the `lms` app index page

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_683fcbf829448330adde03240feed3a9